### PR TITLE
Fix script to package win32 version

### DIFF
--- a/make_dist_win32.sh
+++ b/make_dist_win32.sh
@@ -46,6 +46,8 @@ zipfn="${exefn%.exe}.zip"
 
 rm -rf "${distpath}"
 mkdir -p "${distpath}"
+windeployqt.exe "${exepath}" --dir "${distpath}/${b}"
+
 for f in $(ldd "${exepath}" | awk '{print $3}' | grep 'mingw64'); do
     b=${f##*/}
     cp -v "${f}" "${distpath}/${b}"


### PR DESCRIPTION
Missing some `.dll`s. I'm sure there is a more elegant way to do this, but for now, this seems to work.