### PR TITLE
Setup automatic win32 builds using Appveyor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "maven"]
 	path = maven
-	url = git@github.com:eugenemel/maven.git
+	url = https://github.com/eugenemel/maven.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,34 +10,32 @@ environment:
   PATH: 'C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%'
 
 build_script:
-# Get submodules
-- git submodule update --init --recursive
+  # Get submodules
+  - git submodule update --init --recursive
 
-# Not sure, but seem to have to set path here
-- SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%"
+  # Not sure, but seem to have to set path here
+  - SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%"
 
-# Install 64-bit QT
-#- C:\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-qt-creator
-- bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-qt-creator"
+  # Install 64-bit QT
+  #- C:\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-qt-creator
+  - bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-qt-creator"
 
-# Install zlib
-- bash -lc "pacman -S --needed --noconfirm zlib-devel"
+  # Install zlib
+  - bash -lc "pacman -S --needed --noconfirm zlib-devel"
 
-# Install sqlite3
-- bash -lc "pacman -S --needed --noconfirm mingw64/mingw-w64-x86_64-sqlite3"
-  #- appveyor DownloadFile http://zlib.net/zlib-1.2.11.tar.gz -FileName zlib-1.2.11.tar.gz
-  #- 7z x zlib-1.2.11.tar.gz > NUL
-  #- 7z x zlib-1.2.11.tar > NUL
-  #- cd zlib-1.2.11
-  #- md build
-  #- cd build
-  #- cmake -G "Visual Studio 14 2015 Win64" ..
-  #- cmake --build . --config Release
-  #- copy zconf.h ..
-  #- cd ..
-  #- cd ..
+  # Install sqlite3
+  - bash -lc "pacman -S --needed --noconfirm mingw64/mingw-w64-x86_64-sqlite3"
 
-# Build MAVEN
-- bash -lc "cd $APPVEYOR_BUILD_FOLDER; qmake -r"
-- bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j2"
+  # Build MAVEN
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER; qmake -r"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j2"
 
+after_build:
+    - SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%"
+    - get_version.bat > version.txt
+    - SET /p VERSION=<version.txt
+    - bash -lc "cd $APPVEYOR_BUILD_FOLDER; ./make_dist_win32.sh bin/maven_dev_$VERSION.exe
+
+artifacts:
+    - path: 'dist/maven_*.zip'
+      name: MAVEN

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+version: 1.0.{build}
+environment:
+  matrix:
+  - COMPILER: msys2
+    PLATFORM: x64
+    MSYS2_ARCH: x86_64
+    MSYS2_DIR: msys64
+    MSYSTEM: MINGW64
+    BIT: 64
+  PATH: 'C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%'
+
+build_script:
+# Get submodules
+- git submodule update --init --recursive
+
+# Not sure, but seem to have to set path here
+- SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%"
+
+# Install 64-bit QT
+#- C:\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-qt-creator
+- bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-qt-creator"
+
+# Install zlib
+- bash -lc "pacman -S --needed --noconfirm zlib-devel"
+
+# Install sqlite3
+- bash -lc "pacman -S --needed --noconfirm mingw64/mingw-w64-x86_64-sqlite3"
+  #- appveyor DownloadFile http://zlib.net/zlib-1.2.11.tar.gz -FileName zlib-1.2.11.tar.gz
+  #- 7z x zlib-1.2.11.tar.gz > NUL
+  #- 7z x zlib-1.2.11.tar > NUL
+  #- cd zlib-1.2.11
+  #- md build
+  #- cd build
+  #- cmake -G "Visual Studio 14 2015 Win64" ..
+  #- cmake --build . --config Release
+  #- copy zconf.h ..
+  #- cd ..
+  #- cd ..
+
+# Build MAVEN
+- bash -lc "cd $APPVEYOR_BUILD_FOLDER; qmake -r"
+- bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j2"
+

--- a/get_version.bat
+++ b/get_version.bat
@@ -1,0 +1,3 @@
+@echo off
+SET CURRENT_DATE=%date:~10,4%%date:~4,2%%date:~7,2%
+echo %CURRENT_DATE%

--- a/make_dist_win32.sh
+++ b/make_dist_win32.sh
@@ -52,7 +52,13 @@ for f in $(ldd "${exepath}" | awk '{print $3}' | grep 'mingw64'); do
     b=${f##*/}
     cp -v "${f}" "${distpath}/${b}"
 done
+mkdir -p "${distpath}/methods"
+cp -v bin/methods/* "${distpath}/methods"
+# mkdir -p "${distpath}/pathways"
+# cp -v bin/pathways/* "${distpath}/pathways"
+mkdir -p "${distpath}/scripts"
+cp -v bin/scripts/* "${distpath}/scripts"
 cp -v "${exepath}" "${distpath}/"
 
 rm -rf "dist/${zipfn}"
-(cd "${distpath}" && 7za a -tzip "../${zipfn}" *)
+(cd "${distpath}" && 7z a -tzip "../${zipfn}" *)


### PR DESCRIPTION
This PR adds a configuration file, `appveyor.yml`, that instructs the Appveyor CI service to build a win32 version of maven on each commit (addresses issue #4). It also makes some small changes to the subproject setup to ensure it builds correctly.

There is a one time setup required at Appveyor to add the repository, see https://www.appveyor.com/docs/ for the steps.