### PR TITLE
Automatic linux and osx builds via travis ci

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "maven"]
 	path = maven
-	url = git@github.com:eugenemel/maven.git
+	url = https://github.com/eugenemel/maven.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: osx
+      osx_image: xcode8.3
+
+addons:
+  apt:
+    packages:
+      #- qt5-default
+      - libsqlite3-dev
+
+before_install:
+  - ./ci/travis/before_install_${TRAVIS_OS_NAME}.sh
+  #- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./ci/travis/brew_install_osx.sh; fi
+  #- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt5     ; fi
+
+script:
+  # Add installed Qt path to $PATH
+  - source qt-5.8.0.env
+  - qmake -r
+  - make -j2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,34 +10,32 @@ environment:
   PATH: 'C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%'
 
 build_script:
-# Get submodules
-- git submodule update --init --recursive
+  # Get submodules
+  - git submodule update --init --recursive
 
-# Not sure, but seem to have to set path here
-- SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%"
+  # Not sure, but seem to have to set path here
+  - SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%"
 
-# Install 64-bit QT
-#- C:\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-qt-creator
-- bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-qt-creator"
+  # Install 64-bit QT
+  #- C:\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-qt-creator
+  - bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-qt-creator"
 
-# Install zlib
-- bash -lc "pacman -S --needed --noconfirm zlib-devel"
+  # Install zlib
+  - bash -lc "pacman -S --needed --noconfirm zlib-devel"
 
-# Install sqlite3
-- bash -lc "pacman -S --needed --noconfirm mingw64/mingw-w64-x86_64-sqlite3"
-  #- appveyor DownloadFile http://zlib.net/zlib-1.2.11.tar.gz -FileName zlib-1.2.11.tar.gz
-  #- 7z x zlib-1.2.11.tar.gz > NUL
-  #- 7z x zlib-1.2.11.tar > NUL
-  #- cd zlib-1.2.11
-  #- md build
-  #- cd build
-  #- cmake -G "Visual Studio 14 2015 Win64" ..
-  #- cmake --build . --config Release
-  #- copy zconf.h ..
-  #- cd ..
-  #- cd ..
+  # Install sqlite3
+  - bash -lc "pacman -S --needed --noconfirm mingw64/mingw-w64-x86_64-sqlite3"
 
-# Build MAVEN
-- bash -lc "cd $APPVEYOR_BUILD_FOLDER; qmake -r"
-- bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j2"
+  # Build MAVEN
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER; qmake -r"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j2"
 
+after_build:
+    - SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%"
+    - get_version.bat > version.txt
+    - SET /p VERSION=<version.txt
+    - bash -lc "cd $APPVEYOR_BUILD_FOLDER; ./make_dist_win32.sh bin/maven_dev_$VERSION.exe
+
+artifacts:
+    - path: 'dist/maven_*.zip'
+      name: MAVEN

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+version: 1.0.{build}
+environment:
+  matrix:
+  - COMPILER: msys2
+    PLATFORM: x64
+    MSYS2_ARCH: x86_64
+    MSYS2_DIR: msys64
+    MSYSTEM: MINGW64
+    BIT: 64
+  PATH: 'C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%'
+
+build_script:
+# Get submodules
+- git submodule update --init --recursive
+
+# Not sure, but seem to have to set path here
+- SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%"
+
+# Install 64-bit QT
+#- C:\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-qt-creator
+- bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-qt-creator"
+
+# Install zlib
+- bash -lc "pacman -S --needed --noconfirm zlib-devel"
+
+# Install sqlite3
+- bash -lc "pacman -S --needed --noconfirm mingw64/mingw-w64-x86_64-sqlite3"
+  #- appveyor DownloadFile http://zlib.net/zlib-1.2.11.tar.gz -FileName zlib-1.2.11.tar.gz
+  #- 7z x zlib-1.2.11.tar.gz > NUL
+  #- 7z x zlib-1.2.11.tar > NUL
+  #- cd zlib-1.2.11
+  #- md build
+  #- cd build
+  #- cmake -G "Visual Studio 14 2015 Win64" ..
+  #- cmake --build . --config Release
+  #- copy zconf.h ..
+  #- cd ..
+  #- cd ..
+
+# Build MAVEN
+- bash -lc "cd $APPVEYOR_BUILD_FOLDER; qmake -r"
+- bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j2"
+

--- a/ci/travis/before_install_linux.sh
+++ b/ci/travis/before_install_linux.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Clone QTCI to assist with scripted install of QT
+echo Cloning qtci repository
+git clone https://github.com/benlau/qtci.git
+export PATH="$PATH:$PWD/qtci/bin:$PWD/qtci/recipes"
+
+echo Downloading Qt
+INSTALLER=qt-opensource-linux-x64-5.8.0.run
+ENVFILE=qt-5.8.0.env
+wget -c https://download.qt.io/archive/qt/5.8/5.8.0/qt-opensource-linux-x64-5.8.0.run
+echo Installing Qt
+extract-qt-installer $PWD/$INSTALLER $PWD/Qt
+
+echo Create $ENVFILE
+cat << EOF > $ENVFILE
+export PATH=$PWD/Qt/5.8/gcc_64/bin:$PATH
+EOF
+

--- a/ci/travis/before_install_osx.sh
+++ b/ci/travis/before_install_osx.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+brew update
+brew install qt5
+brew link qt5 --force
+
+ENVFILE=qt-5.8.0.env
+echo Create $ENVFILE
+cat << EOF > $ENVFILE
+export PATH="/usr/local/opt/qt/bin:$PATH"
+EOF

--- a/get_version.bat
+++ b/get_version.bat
@@ -1,0 +1,3 @@
+@echo off
+SET CURRENT_DATE=%date:~10,4%%date:~4,2%%date:~7,2%
+echo %CURRENT_DATE%

--- a/make_dist_win32.sh
+++ b/make_dist_win32.sh
@@ -53,19 +53,11 @@ for f in $(ldd "${exepath}" | awk '{print $3}' | grep 'mingw64'); do
     cp -v "${f}" "${distpath}/${b}"
 done
 mkdir -p "${distpath}/methods"
-<<<<<<< 481bb30845a11fb699e1b48a246a3573c8bb428a
 cp -v bin/methods/* "${distpath}/methods"
 # mkdir -p "${distpath}/pathways"
 # cp -v bin/pathways/* "${distpath}/pathways"
 mkdir -p "${distpath}/scripts"
 cp -v bin/scripts/* "${distpath}/scripts"
-=======
-cp -v bin/methods/* "${apppath}/methods"
-mkdir -p "${distpath}/pathways"
-cp -v bin/pathways/* "${apppath}/pathways"
-mkdir -p "${distpath}/scripts"
-cp -v bin/scripts/* "${apppath}/scripts"
->>>>>>> Added appveyor artifact
 cp -v "${exepath}" "${distpath}/"
 
 rm -rf "dist/${zipfn}"

--- a/make_dist_win32.sh
+++ b/make_dist_win32.sh
@@ -53,11 +53,19 @@ for f in $(ldd "${exepath}" | awk '{print $3}' | grep 'mingw64'); do
     cp -v "${f}" "${distpath}/${b}"
 done
 mkdir -p "${distpath}/methods"
+<<<<<<< 481bb30845a11fb699e1b48a246a3573c8bb428a
 cp -v bin/methods/* "${distpath}/methods"
 # mkdir -p "${distpath}/pathways"
 # cp -v bin/pathways/* "${distpath}/pathways"
 mkdir -p "${distpath}/scripts"
 cp -v bin/scripts/* "${distpath}/scripts"
+=======
+cp -v bin/methods/* "${apppath}/methods"
+mkdir -p "${distpath}/pathways"
+cp -v bin/pathways/* "${apppath}/pathways"
+mkdir -p "${distpath}/scripts"
+cp -v bin/scripts/* "${apppath}/scripts"
+>>>>>>> Added appveyor artifact
 cp -v "${exepath}" "${distpath}/"
 
 rm -rf "dist/${zipfn}"

--- a/make_dist_win32.sh
+++ b/make_dist_win32.sh
@@ -52,7 +52,13 @@ for f in $(ldd "${exepath}" | awk '{print $3}' | grep 'mingw64'); do
     b=${f##*/}
     cp -v "${f}" "${distpath}/${b}"
 done
+mkdir -p "${distpath}/methods"
+cp -v bin/methods/* "${distpath}/methods"
+# mkdir -p "${distpath}/pathways"
+# cp -v bin/pathways/* "${distpath}/pathways"
+mkdir -p "${distpath}/scripts"
+cp -v bin/scripts/* "${distpath}/scripts"
 cp -v "${exepath}" "${distpath}/"
 
 rm -rf "dist/${zipfn}"
-(cd "${distpath}" && 7za a -tzip "../${zipfn}" *)
+(cd "${distpath}" && 7z a -tzip "../${zipfn}" *)


### PR DESCRIPTION
This PR adds a configuration file, `.travis.yml`, that instructs the [Travis CI service](https://travis-ci.org/) to build a linux and osx version of maven on each commit.

There is a one time setup required at Travis to add the repository, see [steps 1 and 2 of the Getting Started guide](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A) for more instructions on setting this up. Merging this PR will create the necessary config (`.travis.yml`).

*Note:* This PR should be merged **after** the PR #5 for Appveyor since the maven submodule update is required by both.